### PR TITLE
feat: add deepseek and chatglm backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ export OPENAI_MODEL=gpt-4o-mini  # or any chat model id
 # Google Gemini
 export GEMINI_API_KEY=...
 export GEMINI_MODEL=gemini-1.5-flash
+
+# DeepSeek
+export DEEPSEEK_API_KEY=...
+export DEEPSEEK_MODEL=deepseek-chat
+
+# ChatGLM (ZhipuAI)
+export CHATGLM_API_KEY=...
+export CHATGLM_MODEL=glm-4-flash
 ```
 
 If no keys are found, the LLM agent falls back to a deterministic **heuristic** model so the


### PR DESCRIPTION
## Summary
- support DeepSeek and ChatGLM LLM backends
- document DeepSeek and ChatGLM environment variables

## Testing
- `pytest`
- `python -m scripts.run_experiment --scenario small --steps 50 --seed 0`

------
https://chatgpt.com/codex/tasks/task_e_68a433e752ec8333982d0ac3bac5b0fb